### PR TITLE
Улучшения dm плагина

### DIFF
--- a/io_scene_xray/fmt_details_imp.py
+++ b/io_scene_xray/fmt_details_imp.py
@@ -6,7 +6,7 @@ from . import fmt_dm_imp
 from .xray_io import ChunkedReader, PackedReader
 
 
-def read_header(data):
+def _read_header(data):
     if len(data) != 24:
         raise Exception(' ! bad details header data. Header size not equal 24')
     pr = PackedReader(data)
@@ -19,31 +19,31 @@ def read_header(data):
 def _get_details_format_version(data):
     cr = ChunkedReader(data)
     has_header = False
-    for chunkId, chunkData in cr:
-        if chunkId == fmt_details.Chunks.HEADER:
+    for chunk_id, chunk_data in cr:
+        if chunk_id == fmt_details.Chunks.HEADER:
             has_header = True
-            format_version = read_header(chunkData)
+            format_version = _read_header(chunk_data)
             return format_version
     if not has_header:
         raise Exception(' ! bad details file. Cannot find HEADER chunk')
 
 
-def read_details_meshes(fpath, cx, data):
+def _read_details_meshes(fpath, cx, data):
     base_name = os.path.basename(fpath.lower())
     root_object = cx.bpy.data.objects.new(base_name, None)
     cx.bpy.context.scene.objects.link(root_object)
     cr = ChunkedReader(data)
-    for meshId, meshData in cr:
-        pr = PackedReader(meshData)
-        mesh_name = base_name + ' mesh_' + str(meshId)
+    for mesh_id, mesh_data in cr:
+        pr = PackedReader(mesh_data)
+        mesh_name = base_name + ' mesh_' + str(mesh_id)
         bpy_obj = fmt_dm_imp._import(mesh_name, cx, pr, mode='DETAILS')
         bpy_obj.parent = root_object
 
 
 def _import(fpath, cx, cr):
-    for chunkId, chunkData in cr:
-        if chunkId == fmt_details.Chunks.MESHES:
-            read_details_meshes(fpath, cx, chunkData)
+    for chunk_id, chunk_data in cr:
+        if chunk_id == fmt_details.Chunks.MESHES:
+            _read_details_meshes(fpath, cx, chunk_data)
 
 
 def import_file(fpath, cx):

--- a/io_scene_xray/fmt_details_imp.py
+++ b/io_scene_xray/fmt_details_imp.py
@@ -3,12 +3,13 @@ import os
 import io
 from . import fmt_details
 from . import fmt_dm_imp
+from .utils import AppError
 from .xray_io import ChunkedReader, PackedReader
 
 
 def _read_header(data):
     if len(data) != 24:
-        raise Exception(' ! bad details header data. Header size not equal 24')
+        raise AppError('bad details header data. Header size not equal 24')
     pr = PackedReader(data)
     format_version, meshes_count, \
     offset_x, offset_z, \
@@ -25,7 +26,7 @@ def _get_details_format_version(data):
             format_version = _read_header(chunk_data)
             return format_version
     if not has_header:
-        raise Exception(' ! bad details file. Cannot find HEADER chunk')
+        raise AppError('bad details file. Cannot find HEADER chunk')
 
 
 def _read_details_meshes(fpath, cx, data):
@@ -53,4 +54,5 @@ def import_file(fpath, cx):
         if format_version in fmt_details.SUPPORT_FORMAT_VERSIONS:
             _import(fpath, cx, ChunkedReader(file_data))
         else:
-            raise Exception(' ! unssuported details format version: {}'.format(format_version))
+            raise AppError('unssuported details format version: {}'.format(
+                format_version))

--- a/io_scene_xray/fmt_dm_exp.py
+++ b/io_scene_xray/fmt_dm_exp.py
@@ -9,16 +9,20 @@ from .xray_io import PackedWriter
 
 def _export(bpy_obj, pw, cx):
     if not len(bpy_obj.data.uv_layers):
-        raise AppError('UV-map is required, but not found')
+        raise AppError('mesh "' + bpy_obj.data.name + '" has no UV-map')
     material_count = len(bpy_obj.material_slots)
     if material_count == 0:
         raise AppError('mesh "' + bpy_obj.data.name + '" has no material')
     elif material_count > 1:
-        raise AppError('mesh "' + bpy_obj.data.name + '" has more than one material')
+        raise AppError(
+            'mesh "' + bpy_obj.data.name + '" has more than one material'
+            )
     else:
         bpy_material = bpy_obj.material_slots[0].material
         if not bpy_material:
-            raise AppError('mesh "' + bpy_obj.data.name + '" has empty material slot')
+            raise AppError(
+                'mesh "' + bpy_obj.data.name + '" has empty material slot'
+                )
     bpy_texture = None
     for ts in bpy_material.texture_slots:
         if ts:
@@ -28,13 +32,18 @@ def _export(bpy_obj, pw, cx):
     if bpy_texture:
         if bpy_texture.type == 'IMAGE':
             if not bpy_texture.image:
-                raise AppError('texture "' + bpy_texture.name + '" has no image')
+                raise AppError(
+                    'texture "' + bpy_texture.name + '" has no image'
+                    )
             if cx.texname_from_path:
                 tx_name = gen_texture_name(bpy_texture, cx.textures_folder)
             else:
                 tx_name = bpy_texture.name
         else:
-            raise AppError('texture "' + bpy_texture.name + '" has an incorrect type: ' + bpy_texture.type)
+            raise AppError(
+                'texture "' + bpy_texture.name + \
+                '" has an incorrect type: ' + bpy_texture.type
+                )
     else:
         raise AppError('material "' + bpy_material.name + '" has no texture')
     pw.puts(bpy_material.xray.eshader)
@@ -61,7 +70,13 @@ def _export(bpy_obj, pw, cx):
                 vertices.append(vtx)
             ii.append(vi)
         indices.append(ii)
-    pw.putf('<I', len(vertices))
+    vertices_count = len(vertices)
+    if vertices_count > 0x10000:
+        raise AppError(
+            'mesh "' + bpy_obj.data.name + \
+            '" has too many vertices. Must be less than 65536'
+            )
+    pw.putf('<I', vertices_count)
     pw.putf('<I', len(indices) * 3)
     for vtx in vertices:
         pw.putf('<fffff', vtx[0][0], vtx[0][2], vtx[0][1], vtx[1][0], vtx[1][1])

--- a/io_scene_xray/fmt_dm_exp.py
+++ b/io_scene_xray/fmt_dm_exp.py
@@ -74,7 +74,7 @@ def _export(bpy_obj, pw, cx):
     if vertices_count > 0x10000:
         raise AppError(
             'mesh "' + bpy_obj.data.name + \
-            '" has too many vertices. Must be no more than 65536'
+            '" has too many vertices. Must be less than 65536'
             )
     pw.putf('<I', vertices_count)
     pw.putf('<I', len(indices) * 3)

--- a/io_scene_xray/fmt_dm_exp.py
+++ b/io_scene_xray/fmt_dm_exp.py
@@ -20,32 +20,29 @@ def _export(bpy_obj, pw, cx):
         if not bpy_material:
             raise AppError('mesh "' + bpy_obj.data.name + '" has empty material slot')
     bpy_texture = None
-    tex_index = None
-    for ts_index, ts in enumerate(bpy_material.texture_slots):
+    for ts in bpy_material.texture_slots:
         if ts:
             bpy_texture = ts.texture
             if bpy_texture:
-                tex_index = ts_index
                 break
     if bpy_texture:
         if bpy_texture.type == 'IMAGE':
             if not bpy_texture.image:
                 raise AppError('texture "' + bpy_texture.name + '" has no image')
             if cx.texname_from_path:
-                tx_name = gen_texture_name(bpy_material.texture_slots[tex_index].texture, cx.textures_folder)
+                tx_name = gen_texture_name(bpy_texture, cx.textures_folder)
             else:
-                tx_name = bpy_material.active_texture.name
+                tx_name = bpy_texture.name
         else:
-            raise AppError('texture "' + bpy_texture.name + '" has no image')
+            raise AppError('texture "' + bpy_texture.name + '" has an incorrect type: ' + bpy_texture.type)
     else:
         raise AppError('material "' + bpy_material.name + '" has no texture')
     pw.puts(bpy_material.xray.eshader)
     pw.puts(tx_name)
-    pw.putf('<I', bpy_obj.xray.no_waving)
+    pw.putf('<I', int(bpy_obj.xray.no_waving))
     pw.putf('<ff', bpy_obj.xray.min_scale, bpy_obj.xray.max_scale)
     bm = convert_object_to_space_bmesh(bpy_obj, mathutils.Matrix.Identity(4))
     bmesh.ops.triangulate(bm, faces=bm.faces)
-    bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.00001)
     bpy_data = bpy.data.meshes.new('.export-dm')
     bm.to_mesh(bpy_data)
     bml_uv = bm.loops.layers.uv.active

--- a/io_scene_xray/fmt_dm_exp.py
+++ b/io_scene_xray/fmt_dm_exp.py
@@ -74,7 +74,7 @@ def _export(bpy_obj, pw, cx):
     if vertices_count > 0x10000:
         raise AppError(
             'mesh "' + bpy_obj.data.name + \
-            '" has too many vertices. Must be less than 65536'
+            '" has too many vertices. Must be no more than 65536'
             )
     pw.putf('<I', vertices_count)
     pw.putf('<I', len(indices) * 3)

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -103,7 +103,10 @@ def _import(fpath, cx, pr, mode='DM'):
         S_HHH = PackedReader.prep('HHH')
         for _ in range(indicesCnt // 3):
             fi = pr.getp(S_HHH)    # face indices
-            bm.faces.new((bm.verts[fi[0]], bm.verts[fi[2]], bm.verts[fi[1]]))
+            try:
+                bm.faces.new((bm.verts[fi[0]], bm.verts[fi[2]], bm.verts[fi[1]]))
+            except ValueError:
+                pass
         bm.faces.ensure_lookup_table()
         uvLayer = bm.loops.layers.uv.new(uvMapName)
         if mode == 'DM':

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -56,6 +56,9 @@ def _import(fpath, cx, pr, mode='DM'):
         if not bpy_material:
             bpy_material = cx.bpy.data.materials.new(texture)
             bpy_material.xray.eshader = shader
+            bpy_material.use_shadeless = True
+            bpy_material.use_transparency = True
+            bpy_material.alpha = 0.0
             bpy_texture = cx.bpy.data.textures.get(texture)
             if bpy_texture:
                 if not hasattr(bpy_texture, 'image'):
@@ -81,6 +84,7 @@ def _import(fpath, cx, pr, mode='DM'):
                     bpy_image = cx.bpy.data.images.new(os.path.basename(texture), 0, 0)
                     bpy_image.source = 'FILE'
                     bpy_image.filepath = abs_image_path + '.dds'
+                    bpy_image.use_alpha = True
                 bpy_texture.image = bpy_image
             else:
                 bpy_texture_slot = bpy_material.texture_slots.add()

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -2,6 +2,7 @@
 import io
 import os
 import bmesh
+from .utils import AppError
 from .xray_io import PackedReader
 
 
@@ -81,7 +82,9 @@ def _import(fpath, cx, pr, mode='DM'):
                         bpy_image = bi
                         break
                 if not bpy_image:
-                    bpy_image = cx.bpy.data.images.new(os.path.basename(texture), 0, 0)
+                    bpy_image = cx.bpy.data.images.new(
+                        os.path.basename(texture), 0, 0
+                        )
                     bpy_image.source = 'FILE'
                     bpy_image.filepath = abs_image_path + '.dds'
                     bpy_image.use_alpha = True
@@ -95,7 +98,7 @@ def _import(fpath, cx, pr, mode='DM'):
         bpy_obj.xray.min_scale = min_scale
         bpy_obj.xray.max_scale = max_scale
         if indices_cnt % 3 != 0:
-            raise Exception(' ! bad dm triangle indices')
+            raise AppError('bad dm triangle indices')
         bm = bmesh.new()
         S_FFFFF = PackedReader.prep('fffff')    
         uvs = {}
@@ -108,7 +111,9 @@ def _import(fpath, cx, pr, mode='DM'):
         for _ in range(indices_cnt // 3):
             fi = pr.getp(S_HHH)    # face indices
             try:
-                bm.faces.new((bm.verts[fi[0]], bm.verts[fi[2]], bm.verts[fi[1]]))
+                bm.faces.new(
+                    (bm.verts[fi[0]], bm.verts[fi[2]], bm.verts[fi[1]])
+                    )
             except ValueError:
                 pass
         bm.faces.ensure_lookup_table()
@@ -123,7 +128,10 @@ def _import(fpath, cx, pr, mode='DM'):
                     uv = uvs[loop.vert]
                     loop[uv_layer].uv = uv[0], 1 - uv[1]
         else:
-            raise Exception(' ! unknown dm import mode: {}'.format(mode))
+            raise Exception(
+                'unknown dm import mode: {0}. ' \
+                'You must use DM or DETAILS'.format(mode)
+                )
         if not bpy_image:
             bpy_image = bpy_material.texture_slots[0].texture.image
         bml_tex = bm.faces.layers.tex.new(uv_map_name)

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -26,8 +26,8 @@ def _import(fpath, cx, pr, mode='DM'):
         cx.bpy.context.scene.objects.link(bpy_obj)
         shader = pr.gets()
         texture = pr.gets()
-        absoluteImagePath = cx.textures_folder + texture
-        uvMapName = 'Texture'
+        abs_image_path = cx.textures_folder + texture
+        uv_map_name = 'Texture'
         bpy_material = None
         bpy_image = None
         bpy_texture = None
@@ -41,7 +41,7 @@ def _import(fpath, cx, pr, mode='DM'):
             for ts in bm.texture_slots:
                 if not ts:
                     continue
-                if ts.uv_layer != uvMapName:
+                if ts.uv_layer != uv_map_name:
                     continue
                 if not hasattr(ts.texture, 'image'):
                     continue
@@ -61,7 +61,7 @@ def _import(fpath, cx, pr, mode='DM'):
                 if not hasattr(bpy_texture, 'image'):
                     bpy_texture = None
                 else:
-                    if bpy_texture.image.filepath != absoluteImagePath + '.dds':
+                    if bpy_texture.image.filepath != abs_image_path + '.dds':
                         bpy_texture = None
             if bpy_texture is None:
                 bpy_texture = cx.bpy.data.textures.new(texture, type='IMAGE')
@@ -69,60 +69,60 @@ def _import(fpath, cx, pr, mode='DM'):
                 bpy_texture_slot = bpy_material.texture_slots.add()
                 bpy_texture_slot.texture = bpy_texture
                 bpy_texture_slot.texture_coords = 'UV'
-                bpy_texture_slot.uv_layer = uvMapName
+                bpy_texture_slot.uv_layer = uv_map_name
                 bpy_texture_slot.use_map_color_diffuse = True
                 bpy_texture_slot.use_map_alpha = True
                 bpy_image = None
                 for bi in cx.bpy.data.images:
-                    if absoluteImagePath in bi.filepath:
+                    if abs_image_path in bi.filepath:
                         bpy_image = bi
                         break
                 if not bpy_image:
                     bpy_image = cx.bpy.data.images.new(os.path.basename(texture), 0, 0)
                     bpy_image.source = 'FILE'
-                    bpy_image.filepath = absoluteImagePath + '.dds'
+                    bpy_image.filepath = abs_image_path + '.dds'
                 bpy_texture.image = bpy_image
             else:
                 bpy_texture_slot = bpy_material.texture_slots.add()
                 bpy_texture_slot.texture = bpy_texture
         bpy_mesh.materials.append(bpy_material)
-        flags, minScale, maxScale, vertsCnt, indicesCnt = pr.getf('<IffII')
+        flags, min_scale, max_scale, verts_cnt, indices_cnt = pr.getf('<IffII')
         bpy_obj.xray.no_waving = bool(flags)
-        bpy_obj.xray.min_scale = minScale
-        bpy_obj.xray.max_scale = maxScale
-        if indicesCnt % 3 != 0:
+        bpy_obj.xray.min_scale = min_scale
+        bpy_obj.xray.max_scale = max_scale
+        if indices_cnt % 3 != 0:
             raise Exception(' ! bad dm triangle indices')
         bm = bmesh.new()
         S_FFFFF = PackedReader.prep('fffff')    
         uvs = {}
-        for _ in range(vertsCnt):
+        for _ in range(verts_cnt):
             v = pr.getp(S_FFFFF)    # x, y, z, u, v
             bm_vert = bm.verts.new((v[0], v[2], v[1]))
             uvs[bm_vert] = (v[3], v[4])
         bm.verts.ensure_lookup_table()
         S_HHH = PackedReader.prep('HHH')
-        for _ in range(indicesCnt // 3):
+        for _ in range(indices_cnt // 3):
             fi = pr.getp(S_HHH)    # face indices
             try:
                 bm.faces.new((bm.verts[fi[0]], bm.verts[fi[2]], bm.verts[fi[1]]))
             except ValueError:
                 pass
         bm.faces.ensure_lookup_table()
-        uvLayer = bm.loops.layers.uv.new(uvMapName)
+        uv_layer = bm.loops.layers.uv.new(uv_map_name)
         if mode == 'DM':
             for face in bm.faces:
                 for loop in face.loops:
-                    loop[uvLayer].uv = uvs[loop.vert]
+                    loop[uv_layer].uv = uvs[loop.vert]
         elif mode == 'DETAILS':
             for face in bm.faces:
                 for loop in face.loops:
                     uv = uvs[loop.vert]
-                    loop[uvLayer].uv = uv[0], 1 - uv[1]
+                    loop[uv_layer].uv = uv[0], 1 - uv[1]
         else:
             raise Exception(' ! unknown dm import mode: {}'.format(mode))
         if not bpy_image:
             bpy_image = bpy_material.texture_slots[0].texture.image
-        bml_tex = bm.faces.layers.tex.new(uvMapName)
+        bml_tex = bm.faces.layers.tex.new(uv_map_name)
         for bmf in bm.faces:
             bmf[bml_tex].image = bpy_image
         bm.normal_update()

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -13,8 +13,6 @@ class ImportContext:
         self.version = version_to_number(*bl_info['version'])
         self.report = report
         self.bpy = bpy
-        if textures[-1] != os.sep:
-            textures += os.sep
         self.textures_folder = textures
         self.op = op
 
@@ -27,7 +25,7 @@ def _import(fpath, cx, pr, mode='DM'):
         cx.bpy.context.scene.objects.link(bpy_obj)
         shader = pr.gets()
         texture = pr.gets()
-        abs_image_path = cx.textures_folder + texture
+        abs_image_path = os.path.abspath(os.path.join(cx.textures_folder, texture + '.dds'))
         uv_map_name = 'Texture'
         bpy_material = None
         bpy_image = None
@@ -65,7 +63,7 @@ def _import(fpath, cx, pr, mode='DM'):
                 if not hasattr(bpy_texture, 'image'):
                     bpy_texture = None
                 else:
-                    if bpy_texture.image.filepath != abs_image_path + '.dds':
+                    if bpy_texture.image.filepath != abs_image_path:
                         bpy_texture = None
             if bpy_texture is None:
                 bpy_texture = cx.bpy.data.textures.new(texture, type='IMAGE')
@@ -78,7 +76,7 @@ def _import(fpath, cx, pr, mode='DM'):
                 bpy_texture_slot.use_map_alpha = True
                 bpy_image = None
                 for bi in cx.bpy.data.images:
-                    if abs_image_path in bi.filepath:
+                    if abs_image_path == bi.filepath:
                         bpy_image = bi
                         break
                 if not bpy_image:
@@ -86,7 +84,10 @@ def _import(fpath, cx, pr, mode='DM'):
                         os.path.basename(texture), 0, 0
                         )
                     bpy_image.source = 'FILE'
-                    bpy_image.filepath = abs_image_path + '.dds'
+                    if not cx.textures_folder:
+                        bpy_image.filepath = texture + '.dds'
+                    else:
+                        bpy_image.filepath = abs_image_path
                     bpy_image.use_alpha = True
                 bpy_texture.image = bpy_image
             else:

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -6,7 +6,7 @@ from .utils import AppError
 from .xray_io import PackedReader
 
 
-def _import(fpath, cx, pr, mode='DM'):
+def import_(fpath, cx, pr, mode='DM'):
     if cx.bpy:
         object_name = os.path.basename(fpath.lower())
         bpy_mesh = cx.bpy.data.meshes.new(object_name)
@@ -134,4 +134,4 @@ def _import(fpath, cx, pr, mode='DM'):
 
 def import_file(fpath, cx):
     with io.open(fpath, 'rb') as f:
-        _import(fpath, cx, PackedReader(f.read()))
+        import_(fpath, cx, PackedReader(f.read()))

--- a/io_scene_xray/fmt_dm_imp.py
+++ b/io_scene_xray/fmt_dm_imp.py
@@ -6,17 +6,6 @@ from .utils import AppError
 from .xray_io import PackedReader
 
 
-class ImportContext:
-    def __init__(self, textures, report, op, bpy=None):
-        from . import bl_info
-        from .utils import version_to_number
-        self.version = version_to_number(*bl_info['version'])
-        self.report = report
-        self.bpy = bpy
-        self.textures_folder = textures
-        self.op = op
-
-
 def _import(fpath, cx, pr, mode='DM'):
     if cx.bpy:
         object_name = os.path.basename(fpath.lower())

--- a/io_scene_xray/plugin.py
+++ b/io_scene_xray/plugin.py
@@ -197,9 +197,13 @@ class OpImportDM(TestReadyOperator, io_utils.ImportHelper):
             return {'CANCELLED'}
         from . import fmt_dm_imp
         from . import fmt_details_imp
-        cx = fmt_dm_imp.ImportContext(
+        from .fmt_object_imp import ImportContext
+        cx = ImportContext(
             report=self.report,
             textures=textures_folder,
+            soc_sgroups=None,
+            import_motions=None,
+            split_by_materials=None,
             op=self,
             bpy=bpy
         )

--- a/io_scene_xray/plugin.py
+++ b/io_scene_xray/plugin.py
@@ -459,13 +459,18 @@ class OpExportDM(bpy.types.Operator, io_utils.ExportHelper):
         if objs[0].type != 'MESH':
             self.report({'ERROR'}, 'The selected object is not a mesh')
             return {'CANCELLED'}
-        return self.export(objs[0], context)
+        try:
+            self.export(objs[0], context)
+        except AppError as err:
+            self.report({'ERROR'}, str(err))
+            return {'CANCELLED'}
+        return {'FINISHED'}
 
     def export(self, bpy_obj, context):
         from .fmt_dm_exp import export_file
         cx = _mk_export_context(context, self.report, self.texture_name_from_image_path)
         export_file(bpy_obj, self.filepath, cx)
-        return {'FINISHED'}
+
 
     def invoke(self, context, event):
         prefs = plugin_prefs.get_preferences()

--- a/io_scene_xray/plugin.py
+++ b/io_scene_xray/plugin.py
@@ -204,14 +204,18 @@ class OpImportDM(TestReadyOperator, io_utils.ImportHelper):
             bpy=bpy
         )
         import os.path
-        for file in self.files:
-            ext = os.path.splitext(file.name)[-1].lower()
-            if ext == '.dm':
-                fmt_dm_imp.import_file(os.path.join(self.directory, file.name), cx)
-            elif ext == '.details':
-                fmt_details_imp.import_file(os.path.join(self.directory, file.name), cx)
-            else:
-                self.report({'ERROR'}, 'Format of {} not recognised'.format(file))
+        try:
+            for file in self.files:
+                ext = os.path.splitext(file.name)[-1].lower()
+                if ext == '.dm':
+                    fmt_dm_imp.import_file(os.path.join(self.directory, file.name), cx)
+                elif ext == '.details':
+                    fmt_details_imp.import_file(os.path.join(self.directory, file.name), cx)
+                else:
+                    self.report({'ERROR'}, 'Format of {} not recognised'.format(file))
+        except AppError as err:
+            self.report({'ERROR'}, str(err))
+            return {'CANCELLED'}
         return {'FINISHED'}
 
     def draw(self, context):


### PR DESCRIPTION
1. Теперь при экспорте в dm выскакивает окошко с предупреждением вместо ошибки.

2. Объединены меню импорта dm и details файлов (теперь оно называется `X-Ray detail model (.dm, .details)`)

3. Более правильный поиск и экспорт текстуры и флагов.
Удалено remove_doubles, так как это действие лишнее.

4. При экспорте меша со слишком большим количеством вершин, выдаётся предупреждение (ограничение формата на количество вершин 0xffff).
Изменил предупреждение при отсутствии UV карты на более точное (с выводом имени проблемного меша).
Изменил строки кода так, чтобы они умещались в ширину 79 символов.

5. Исправлен баг при импорте dm: #105 

6. Исправлена опечатка в тексте предупреждения.

7. Изменил имена переменных, чтобы соответствовали PEP8.
Случайно удалил предыдущий фикс текста предупреждения.

8. Вернул удалённый фикс текста предупреждения.

9. Параметры прозрачности у материалов и текстур устанавливаются включёнными по-умолчанию.

10. При импорте dm и details выдаются предупреждения вместо ошибок.

11. При импорте dm/details и отсутствии textures в настройках, плагин всё равно импортирует меш.

12. Класс ImportContext удалён из fmt_dm_imp. Теперь используется аналогичный класс из fmt_object_imp.

13. Переписал большую часть кода импорта details. Теперь имена мешей имеют двухзначный номер (например 09).
Более правильная выдача предупреждений.
Весь код импорта и обработки ошибок перенесён в одну функцию (раньше некоторые части кода импорта были в функциях import_file, _read_header).

