### PR TITLE
ошибочный экспорт источников света

### DIFF
--- a/io_scene_xray/fmt_object_imp.py
+++ b/io_scene_xray/fmt_object_imp.py
@@ -7,15 +7,13 @@ import os.path
 from .xray_io import ChunkedReader, PackedReader
 from .fmt_object import Chunks
 from .plugin_prefs import PropObjectMeshSplitByMaterials
-from .utils import BAD_VTX_GROUP_NAME
+from .utils import BAD_VTX_GROUP_NAME, plugin_version_number
 from .xray_motions import import_motions
 
 
 class ImportContext:
     def __init__(self, textures, soc_sgroups, import_motions, split_by_materials, report, op, bpy=None):
-        from . import bl_info
-        from .utils import version_to_number
-        self.version = version_to_number(*bl_info['version'])
+        self.version = plugin_version_number()
         self.report = report
         self.bpy = bpy
         self.textures_folder = textures

--- a/io_scene_xray/utils.py
+++ b/io_scene_xray/utils.py
@@ -13,6 +13,15 @@ def version_to_number(major, minor, release):
     return ((major & 0xff) << 24) | ((minor & 0xff) << 16) | (release & 0xffff)
 
 
+_plugin_version_number = 0
+def plugin_version_number():
+    global _plugin_version_number
+    if _plugin_version_number == 0:
+        from . import bl_info
+        _plugin_version_number = version_to_number(*bl_info['version'])
+    return _plugin_version_number
+
+
 class AppError(Exception):
     def __init__(self, message):
         super().__init__(message)

--- a/io_scene_xray/xray_inject.py
+++ b/io_scene_xray/xray_inject.py
@@ -152,7 +152,9 @@ class XRayObjectProperties(bpy.types.PropertyGroup):
     no_waving = bpy.props.BoolProperty(description='No Waving', options={'SKIP_SAVE'}, default=False)
     min_scale = bpy.props.FloatProperty(default=1.0, min=0.1, max=100.0)
     max_scale = bpy.props.FloatProperty(default=1.0, min=0.1, max=100.0)
-    
+
+    def initialize(self, obj):
+        self.root = obj.type == 'MESH'
 
 
 class XRayMeshProperties(bpy.types.PropertyGroup):

--- a/tests/cases/test_objinit.py
+++ b/tests/cases/test_objinit.py
@@ -1,0 +1,46 @@
+from tests import utils
+
+import bpy
+from io_scene_xray import plugin, utils as utl
+
+
+class TestObjectInitialize(utils.XRayTestCase):
+    def test_import_version_and_root(self):
+        # Arrange
+        version = utl.plugin_version_number()
+
+        # Act
+        bpy.ops.xray_import.object(
+            directory=self.relpath(),
+            files=[{'name': 'test_fmt.object'}],
+        )
+        plugin.scene_update_post(bpy.context.scene)
+
+        # Assert
+        obj = bpy.data.objects['test_fmt.object']
+        self.assertEqual(obj.xray.version, version)
+        self.assertEqual(obj.xray.root, True)
+
+    def test_init_version(self):
+        # Arrange
+        obj = bpy.data.objects.new('obj', None)
+
+        # Act
+        plugin.scene_update_post(bpy.context.scene)
+
+        # Assert
+        self.assertNotEqual(obj.xray.version, 0)
+
+    def test_init_root(self):
+        # Arrange
+        obj_mesh = bpy.data.objects.new('mesh', bpy.data.meshes.new('mesh'))
+        obj_arma = bpy.data.objects.new('arma', bpy.data.armatures.new('arma'))
+        obj_lamp = bpy.data.objects.new('lamp', bpy.data.lamps.new('lamp', 'POINT'))
+
+        # Act
+        plugin.scene_update_post(bpy.context.scene)
+
+        # Assert
+        self.assertEqual(obj_mesh.xray.root, True)
+        self.assertEqual(obj_arma.xray.root, False)
+        self.assertEqual(obj_lamp.xray.root, False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,6 +37,8 @@ class XRayTestCase(unittest.TestCase):
         else:
             bpy.ops.wm.read_homefile()
         addon_utils.enable('io_scene_xray', default_set=True)
+        from io_scene_xray import plugin
+        plugin.load_post(None)
         self.__prev_report_catcher = TestReadyOperator.report_catcher
         TestReadyOperator.report_catcher = lambda op, type, message: self._reports.append((type, message))
 


### PR DESCRIPTION
Х/з, что делать с существующими объектами (в blend-файлах).
А при добавлении нового объекта, теперь проверяется его тип и флаг "XRay - object root" выставляется только если тип объекта == MESH.
(fixes #102)