### PR TITLE
import objects: almost without EMPTY

### DIFF
--- a/io_scene_xray/fmt_object_exp.py
+++ b/io_scene_xray/fmt_object_exp.py
@@ -69,7 +69,8 @@ def _export_sg_new(bmfaces):
 
 def _export_mesh(bpy_obj, bpy_root, cw, cx):
     cw.put(Chunks.Mesh.VERSION, PackedWriter().putf('H', 0x11))
-    cw.put(Chunks.Mesh.MESHNAME, PackedWriter().puts(bpy_obj.name))
+    mesh_name = bpy_obj.data.name if bpy_obj == bpy_root else bpy_obj.name
+    cw.put(Chunks.Mesh.MESHNAME, PackedWriter().puts(mesh_name))
 
     bm = convert_object_to_space_bmesh(bpy_obj, bpy_root.matrix_world)
     bml = bm.verts.layers.deform.verify()

--- a/io_scene_xray/fmt_object_imp.py
+++ b/io_scene_xray/fmt_object_imp.py
@@ -289,7 +289,7 @@ def _import_mesh(cx, cr, renamemap):
 
     bmfaces = [None] * len(fc_data)
 
-    bm_data = bpy.data.meshes.new(mesh_name + '.mesh')
+    bm_data = bpy.data.meshes.new(mesh_name)
     if face_sg:
         bm_data.use_auto_smooth = True
         bm_data.auto_smooth_angle = math.pi
@@ -709,6 +709,7 @@ def _import_main(fpath, cx, cr):
     if bpy_obj is None:
         if len(mesh_objects) == 1:
             bpy_obj = mesh_objects[0]
+            bpy_obj.name = object_name
         else:
             bpy_obj = bpy.data.objects.new(object_name, None)
             for m in mesh_objects:

--- a/tests/cases/test_armature.py
+++ b/tests/cases/test_armature.py
@@ -32,5 +32,10 @@ class TestArmature(utils.XRayTestCase):
             directory=self.outpath(),
             files=[{'name': 'test.object'}],
         )
+
+        obj_arm = bpy.data.objects[-1]
+        self.assertEqual(obj_arm.type, 'ARMATURE')
+        self.assertEqual(obj_arm.xray.isroot, True)
+
         imp_arm = bpy.data.armatures[1]
         self.assertEqual(len(imp_arm.bones), 1)

--- a/tests/cases/test_fmt_object.py
+++ b/tests/cases/test_fmt_object.py
@@ -137,7 +137,9 @@ class TestFormatObject(utils.XRayTestCase):
 
         # Assert
         self.assertReportsNotContains('WARNING')
-        imported_material = bpy.data.objects['Plane'].data.materials[0]
+        imported_object = bpy.data.objects['test_fmt.object']
+        self.assertEqual(imported_object.data.name, 'Plane')
+        imported_material = imported_object.data.materials[0]
         self.assertNotEqual(imported_material, mat)
         imported_texture = imported_material.texture_slots[0].texture
         self.assertNotEqual(imported_texture, tex)
@@ -154,10 +156,31 @@ class TestFormatObject(utils.XRayTestCase):
 
         # Assert
         self.assertReportsNotContains('WARNING')
-        imported_material = bpy.data.objects['Plane'].data.materials[0]
+        imported_material = bpy.data.objects['test_fmt.object'].data.materials[0]
         self.assertEqual(imported_material, mat)
         imported_texture = imported_material.texture_slots[0].texture
         self.assertEqual(imported_texture, tex)
+
+    def test_export_single_mesh(self):
+        # Arrange
+        bpy.ops.xray_import.object(
+            directory=self.relpath(),
+            files=[{'name': 'test_fmt.object'}],
+        )
+
+        obj = bpy.data.objects[-1]
+        obj.name = 'uniq-obj-name'
+        obj.data.name = 'uniq-msh-name'
+
+        # Act
+        bpy.ops.export_object.xray_objects(
+            objects=obj.name, directory=self.outpath(),
+            texture_name_from_image_path=False,
+            export_motions=False,
+        )
+
+        # Assert
+        self.assertFileContains('uniq-obj-name.object', re.compile(b'uniq-msh-name'))
 
     def _get_compatible_material(self):
         img = bpy.data.images.new('texture', 0, 0)

--- a/tests/cases/test_objinit.py
+++ b/tests/cases/test_objinit.py
@@ -17,7 +17,7 @@ class TestObjectInitialize(utils.XRayTestCase):
         plugin.scene_update_post(bpy.context.scene)
 
         # Assert
-        obj = bpy.data.objects['test_fmt.object']
+        obj = bpy.data.objects['Plane']
         self.assertEqual(obj.type, 'MESH')
         self.assertEqual(obj.xray.version, version)
         self.assertEqual(obj.xray.root, True)

--- a/tests/cases/test_objinit.py
+++ b/tests/cases/test_objinit.py
@@ -17,8 +17,9 @@ class TestObjectInitialize(utils.XRayTestCase):
         plugin.scene_update_post(bpy.context.scene)
 
         # Assert
-        obj = bpy.data.objects['Plane']
+        obj = bpy.data.objects['test_fmt.object']
         self.assertEqual(obj.type, 'MESH')
+        self.assertEqual(obj.data.name, 'Plane')
         self.assertEqual(obj.xray.version, version)
         self.assertEqual(obj.xray.root, True)
 

--- a/tests/cases/test_objinit.py
+++ b/tests/cases/test_objinit.py
@@ -18,6 +18,7 @@ class TestObjectInitialize(utils.XRayTestCase):
 
         # Assert
         obj = bpy.data.objects['test_fmt.object']
+        self.assertEqual(obj.type, 'MESH')
         self.assertEqual(obj.xray.version, version)
         self.assertEqual(obj.xray.root, True)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import unittest
 import addon_utils
+import io
 import inspect
 import os
 import shutil
@@ -78,6 +79,16 @@ class XRayTestCase(unittest.TestCase):
         orphaned = existing - expected
         if orphaned:
             self.fail(self._formatMessage(None, 'files {} orphaned'.format(orphaned)))
+
+    def assertFileContains(self, file_path, re_message=None):
+        full_path = os.path.join(XRayTestCase.__tmp, file_path)
+        content = ''
+        with io.open(full_path, 'rb') as f:
+            content = f.read()
+        match = re_message.match(content.replace(b'\x00', b''))
+        if match is not None:
+            raise self.fail('Cannot match the \'{}\' file content with \'{}\''
+                            .format(file_path, re_message))
 
     def _findReport(self, type=None, re_message=None):
         for r in self._reports:


### PR DESCRIPTION
~В данном фиксе есть один недостаток - при импорте static object-а содержащего только 1 меш, имя файла теряется (т.к. раньше оно записывалось в имя Empty-объекта, которые теперь не создаются).~
Поправил, теперь для static object-ов содержащих только 1 меш имя файла берётся из названия оъекта (как объчно), а имя меша теперь берётся из названия меша (**новое поведение**).

(resolve #31)