### PR TITLE
нет unregister для классов

### DIFF
--- a/io_scene_xray/__init__.py
+++ b/io_scene_xray/__init__.py
@@ -11,8 +11,14 @@ bl_info = {
     'warning':  'Under construction!'
 }
 
-try:
-    #noinspection PyUnresolvedReferences
-    from .plugin import register, unregister
-except ImportError:
-    pass
+
+def register():
+    from . import registry, plugin, xray_inject_ui
+    registry.register_thing(plugin, __name__)
+    registry.register_thing(xray_inject_ui, __name__)
+
+
+def unregister():
+    from . import registry, plugin, xray_inject_ui
+    registry.unregister_thing(xray_inject_ui, __name__)
+    registry.unregister_thing(plugin, __name__)

--- a/io_scene_xray/plugin_prefs.py
+++ b/io_scene_xray/plugin_prefs.py
@@ -1,4 +1,5 @@
 import bpy
+from . import registry
 
 
 def get_preferences():
@@ -76,6 +77,7 @@ def PropUseExportPaths():
     )
 
 
+@registry.module_thing
 class PluginPreferences(bpy.types.AddonPreferences):
     bl_idname = 'io_scene_xray'
 
@@ -136,11 +138,3 @@ class PluginPreferences(bpy.types.AddonPreferences):
                 prop_bool(bx, self, 'anm_create_camera')
 
         prop_bool(layout, self, 'expert_mode')
-
-
-def register():
-    bpy.utils.register_class(PluginPreferences)
-
-
-def unregister():
-    bpy.utils.unregister_class(PluginPreferences)

--- a/io_scene_xray/registry.py
+++ b/io_scene_xray/registry.py
@@ -1,0 +1,87 @@
+import bpy
+import sys
+
+_REGISTERED_THINGS = dict()
+
+
+def requires(*things):
+    def decorator(thing):
+        _process_and_set_requires(thing, things)
+        return thing
+    return decorator
+
+
+def module_requires(name, things):
+    module = sys.modules[name]
+    _process_and_set_requires(module, things)
+
+
+def module_thing(thing):
+    module_requires(thing.__dict__['__module__'], [thing])
+    return thing
+
+
+def _default_user():
+    pass
+    # import inspect
+    # curframe = inspect.currentframe()
+    # calframe = inspect.getouterframes(curframe, 10)[9]
+    # return '%s(%s:%d)' % (calframe.function, calframe.filename, calframe.lineno)
+
+
+def register_thing(thing, user=_default_user()):
+    users = _REGISTERED_THINGS.get(thing)
+    if users is None:
+        _REGISTERED_THINGS[thing] = users = list()
+        required = getattr(thing, '__required_things', [])
+        for req in required:
+            register_thing(req, thing)
+        try:
+            bpy.utils.register_class(thing)
+        except ValueError:
+            call = getattr(thing, 'register', None)
+            if callable(call):
+                call()
+            elif required == []:
+                raise Exception('Unsupported thing %s' % thing)
+    users.append(user)
+
+
+def unregister_thing(thing, user=_default_user()):
+    users = _REGISTERED_THINGS.get(thing)
+    if users is None:
+        raise Exception('Thing %s is not registered' % thing)
+    try:
+        users.remove(user)
+    except ValueError as ex:
+        if user not in users:
+            raise Exception('Thing %s is not registered for user %s' % (thing, user))
+        raise ex
+    if users == []:
+        required = getattr(thing, '__required_things', [])
+        for req in reversed(required):
+            unregister_thing(req, thing)
+        try:
+            bpy.utils.unregister_class(thing)
+        except ValueError:
+            call = getattr(thing, 'unregister', None)
+            if callable(call):
+                call()
+            elif required == []:
+                raise Exception('Unsupported thing %s' % thing)
+        del _REGISTERED_THINGS[thing]
+
+
+def dump():
+    for thing, required_by in _REGISTERED_THINGS.items():
+        print(thing, required_by)
+
+
+def _process_and_set_requires(thing, things):
+    values = [getattr(thing, c) if isinstance(c, str) else c for c in things]
+
+    required = getattr(thing, '__required_things', None)
+    if required is None:
+        required = []
+        setattr(thing, '__required_things', required)
+    required.extend(values)

--- a/io_scene_xray/shape_edit_helper.py
+++ b/io_scene_xray/shape_edit_helper.py
@@ -3,6 +3,7 @@ import bmesh
 import math
 import mathutils
 from . import utils
+from . import registry
 
 __HELPER_NAME = utils.HELPER_OBJECT_NAME_PREFIX + 'bone-shape-edit'
 
@@ -115,6 +116,7 @@ def is_helper_object(obj):
     return obj.name == __HELPER_NAME
 
 
+@registry.module_thing
 class _ShapeEditApplyOp(bpy.types.Operator):
     bl_idname = 'io_scene_xray.shape_edit_apply'
     bl_label = 'Apply Shape'
@@ -191,6 +193,7 @@ def _bone_vertices(bone):
                 yield v.co
 
 
+@registry.module_thing
 class _ShapeEditFitOp(bpy.types.Operator):
     bl_idname = 'io_scene_xray.shape_edit_fit'
     bl_label = 'Fit Shape'
@@ -262,13 +265,3 @@ def draw(layout, bone):
 def draw_helper(layout, obj):
     layout.operator(_ShapeEditFitOp.bl_idname, icon='BBOX')
     layout.operator(_ShapeEditApplyOp.bl_idname, icon='FILE_TICK')
-
-
-def register():
-    bpy.utils.register_class(_ShapeEditApplyOp)
-    bpy.utils.register_class(_ShapeEditFitOp)
-
-
-def unregister():
-    bpy.utils.unregister_class(_ShapeEditFitOp)
-    bpy.utils.unregister_class(_ShapeEditApplyOp)

--- a/io_scene_xray/ui_dynmenu.py
+++ b/io_scene_xray/ui_dynmenu.py
@@ -1,6 +1,8 @@
 import bpy
+from . import registry
 
 
+@registry.module_thing
 class _DynamicMenuOp(bpy.types.Operator):
     bl_idname = 'io_scene_xray.dynmenu'
     bl_label = ''
@@ -69,11 +71,3 @@ class DynamicMenu(bpy.types.Menu):
     @staticmethod
     def set_layout_context_data(layout, data):
         layout.context_pointer_set(_DynamicMenuOp.bl_idname + '.data', data)
-
-
-def register():
-    bpy.utils.register_class(_DynamicMenuOp)
-
-
-def unregister():
-    bpy.utils.unregister_class(_DynamicMenuOp)

--- a/io_scene_xray/ui_list.py
+++ b/io_scene_xray/ui_list.py
@@ -1,6 +1,8 @@
 import bpy
+from . import registry
 
 
+@registry.module_thing
 class _ListOp(bpy.types.Operator):
     bl_idname = 'io_scene_xray.list'
     bl_label = ''
@@ -46,11 +48,3 @@ def draw_list_ops(layout, dataptr, propname, active_propname):
     op('del', 'ZOOMOUT', enabled=(index >= 0) and (index < len(collection)))
     op('mup', 'TRIA_UP', enabled=(index > 0) and (index < len(collection)))
     op('mdown', 'TRIA_DOWN', enabled=(index >= 0) and (index < len(collection) - 1))
-
-
-def register():
-    bpy.utils.register_class(_ListOp)
-
-
-def unregister():
-    bpy.utils.unregister_class(_ListOp)

--- a/tests/cases/test_addon.py
+++ b/tests/cases/test_addon.py
@@ -14,3 +14,33 @@ class TestAddon(utils.XRayTestCase):
     def test_preferences(self):
         from io_scene_xray import plugin_prefs
         self.assertIsNotNone(plugin_prefs.get_preferences())
+
+    def test_registry_register_bad_thing(self):
+        from io_scene_xray import registry
+        try:
+            registry.register_thing(self)
+            self.fail('Should fail with an exception')
+        except Exception as ex:
+            self.assertIn('Unsupported thing', str(ex))
+
+    def test_registry_unregister_nonexistent_thing(self):
+        from io_scene_xray import registry
+        try:
+            registry.unregister_thing(self)
+            self.fail('Should fail with an exception')
+        except Exception as ex:
+            self.assertIn('is not registered', str(ex))
+
+    def test_registry_unregister_nonown_thing(self):
+        from io_scene_xray import registry
+        try:
+            thing = _Thing()
+            registry.register_thing(thing, user='some-user')
+            registry.unregister_thing(thing)
+            self.fail('Should fail with an exception')
+        except Exception as ex:
+            self.assertIn('is not registered', str(ex))
+
+class _Thing:
+    def register(self):
+        pass


### PR DESCRIPTION
Явные вызовы register/unregister для классов и модулей теперь заменены на декларативное описание зависимостей.

(resolves: #128)