### PR TITLE
Изменена сортировка в динамическом меню

### DIFF
--- a/io_scene_xray/xray_inject_ui.py
+++ b/io_scene_xray/xray_inject_ui.py
@@ -231,12 +231,16 @@ class XRayXrMenuTemplate(dynamic_menu.DynamicMenu):
 
         def dict_to_array(dct):
             result = []
+            root_result = []
             for (key, val) in dct.items():
                 if isinstance(val, str):
-                    result.append((key, val))
+                    root_result.append((key, val))
                 else:
                     result.append((key, dict_to_array(val)))
-            return sorted(result, key=lambda e: e[0])
+            result = sorted(result, key=lambda e: e[0])
+            root_result = sorted(root_result, key=lambda e: e[0])
+            result.extend(root_result)
+            return result
 
         tmp = dict()
         for (name, _) in fparse(data):


### PR DESCRIPTION
Теперь каталоги с шейдерами идут первее, чем корневые шейдеры.
![1](https://user-images.githubusercontent.com/7983249/48710044-496c3a80-ec18-11e8-9396-4ded6eb4911a.jpg)
resolved #207 