### PR TITLE
Add scale option for skl import

### DIFF
--- a/io_scene_xray/obj/imp/main.py
+++ b/io_scene_xray/obj/imp/main.py
@@ -327,6 +327,7 @@ def import_main(fpath, context, creader):
                 armature=bpy_arm_obj,
                 motions_filter=xray_motions.MOTIONS_FILTER_ALL,
                 prefix=context.use_motion_prefix_name,
+                scale=1,
                 filename=object_name
             )
             xray_motions.import_motions(reader, skl_context)

--- a/io_scene_xray/skl/imp.py
+++ b/io_scene_xray/skl/imp.py
@@ -6,10 +6,11 @@ from .. import log
 
 
 class ImportContext:
-    def __init__(self, armature, motions_filter, prefix, filename):
+    def __init__(self, armature, motions_filter, prefix, scale, filename):
         self.armature = armature
         self.motions_filter = motions_filter
         self.use_motion_prefix_name = prefix
+        self.motion_scale = scale
         self.filename = filename
 
 

--- a/io_scene_xray/skl/ops.py
+++ b/io_scene_xray/skl/ops.py
@@ -38,7 +38,8 @@ op_import_skl_props = {
     'directory': bpy.props.StringProperty(subtype='DIR_PATH'),
     'files': bpy.props.CollectionProperty(type=bpy.types.OperatorFileListElement),
     'motions': bpy.props.CollectionProperty(type=Motion, name='Motions Filter'),
-    'use_motion_prefix_name': bpy.props.BoolProperty(default=False, name='Motion Prefix Name')
+    'use_motion_prefix_name': bpy.props.BoolProperty(default=False, name='Motion Prefix Name'),
+    'motion_scale': bpy.props.FloatProperty(default=1, name='Motion Scale')
 }
 
 
@@ -59,6 +60,10 @@ class OpImportSkl(TestReadyOperator, io_utils.ImportHelper):
     def draw(self, context):
         layout = self.layout
         layout.prop(self, 'use_motion_prefix_name')
+        row = layout.row()
+        row.enabled = False
+        row.label(text='%d items' % len(self.files))
+        layout.prop(self, 'motion_scale')
         row = layout.row()
         row.enabled = False
         row.label(text='%d items' % len(self.files))
@@ -132,6 +137,7 @@ class OpImportSkl(TestReadyOperator, io_utils.ImportHelper):
             armature=context.active_object,
             motions_filter=motions_filter,
             prefix=self.use_motion_prefix_name,
+            scale=self.motion_scale,
             filename=None
         )
         for file in self.files:

--- a/io_scene_xray/skls_browser.py
+++ b/io_scene_xray/skls_browser.py
@@ -180,6 +180,7 @@ def skls_animations_index_changed(self, context):
             armature=ob,
             motions_filter=MOTIONS_FILTER_ALL,
             prefix=False,
+            scale=1,
             filename=OpBrowseSklsFile.skls_file.file_path
         )
         import_motion(OpBrowseSklsFile.skls_file.pr, import_context, bonesmap, reported)

--- a/io_scene_xray/xray_motions.py
+++ b/io_scene_xray/xray_motions.py
@@ -112,9 +112,9 @@ def import_motion(reader, context, bonesmap, reported, motions_filter=MOTIONS_FI
                 mat = multiply(
                     xmat,
                     Matrix.Translation((
-                        +tmpfc[0].evaluate(time),
-                        +tmpfc[1].evaluate(time),
-                        -tmpfc[2].evaluate(time),
+                        +tmpfc[0].evaluate(time) * context.motion_scale,
+                        +tmpfc[1].evaluate(time) * context.motion_scale,
+                        -tmpfc[2].evaluate(time) * context.motion_scale,
                     )),
                     Euler((
                         -tmpfc[4].evaluate(time),


### PR DESCRIPTION
Для моего проекта нужно было увеличить все модели в 100 раз, дабы корректно работала физика в UE4. Но при проигрывании анимаций после увеличения персонаж повисал в воздухе.
Лучшим решением оказалось умножать анимации на 100 при импорте и я решил вынести это в параметр.