### PR TITLE
Модуль xray_io работает вне блендера

### DIFF
--- a/io_scene_xray/plugin.py
+++ b/io_scene_xray/plugin.py
@@ -5,7 +5,7 @@ import bpy
 import bpy.utils.previews
 from bpy_extras import io_utils
 
-from . import xray_inject
+from . import xray_inject, xray_io
 from .ops import BaseOperator as TestReadyOperator
 from .ui import collapsible, motion_list
 from .utils import (
@@ -27,6 +27,8 @@ from .version_utils import (
     get_import_export_menus, get_scene_update_post, assign_props, IS_28
 )
 
+
+xray_io.ENCODE_ERROR = AppError
 
 op_export_project_props = {
     'filepath': bpy.props.StringProperty(subtype='DIR_PATH', options={'SKIP_SAVE'}),

--- a/io_scene_xray/xray_io.py
+++ b/io_scene_xray/xray_io.py
@@ -1,11 +1,8 @@
 import struct
 from .lzhuf import decompress_buffer
 
-try:
-    from .utils import AppError
-    error = AppError
-except:
-    error = BaseException
+
+ENCODE_ERROR = BaseException
 
 
 class FastBytes:
@@ -167,7 +164,7 @@ class PackedWriter():
         try:
             self.data += string.encode('cp1251')
         except UnicodeEncodeError:
-            raise error('Not valid string: {}'.format(string))
+            raise ENCODE_ERROR('Not valid string: {}'.format(string))
         self.data += b'\x00'
         return self
 

--- a/io_scene_xray/xray_io.py
+++ b/io_scene_xray/xray_io.py
@@ -1,6 +1,11 @@
 import struct
 from .lzhuf import decompress_buffer
-from .utils import AppError
+
+try:
+    from .utils import AppError
+    error = AppError
+except:
+    error = BaseException
 
 
 class FastBytes:

--- a/io_scene_xray/xray_io.py
+++ b/io_scene_xray/xray_io.py
@@ -167,7 +167,7 @@ class PackedWriter():
         try:
             self.data += string.encode('cp1251')
         except UnicodeEncodeError:
-            raise AppError('Not valid string: {}'.format(string))
+            raise error('Not valid string: {}'.format(string))
         self.data += b'\x00'
         return self
 


### PR DESCRIPTION
Теперь есть возможность использовать xray_io модуль вне блендера, так как в таком случае будет использоваться исключение BaseException, вместо AppError.