### PR TITLE
Генерация progressive для ogf

### DIFF
--- a/io_scene_xray/panels/mesh.py
+++ b/io_scene_xray/panels/mesh.py
@@ -42,6 +42,10 @@ class XRAY_PT_mesh(ui.base.XRayPanel):
         row.prop(data, 'flags_locked', text='Locked', toggle=True)
         row.prop(data, 'flags_sgmask', text='SGMask', toggle=True)
 
+        split = version_utils.layout_split(layout, 0.333)
+        split.label(text='LOD Modifier:')
+        split.prop_search(data, 'lodifier', context.object, 'modifiers', text='')
+
 
 def register():
     bpy.utils.register_class(XRAY_PT_mesh)

--- a/io_scene_xray/props/mesh.py
+++ b/io_scene_xray/props/mesh.py
@@ -20,7 +20,11 @@ xray_mesh_properties = {
     'flags': bpy.props.IntProperty(name='flags', default=0x1),
     'flags_visible': utility.gen_flag_prop(mask=0x01),
     'flags_locked': utility.gen_flag_prop(mask=0x02),
-    'flags_sgmask': utility.gen_flag_prop(mask=0x04)
+    'flags_sgmask': utility.gen_flag_prop(mask=0x04),
+    'lodifier': bpy.props.StringProperty(
+        name='LOD Modifier',
+        description='A modification which ratio will be iterated to generate several LODs',
+    ),
 }
 
 


### PR DESCRIPTION
Решает #470

Пример получившегося файла:
<video src="https://user-images.githubusercontent.com/5264687/155866868-ddd628a3-9c72-43f2-9a95-5a5dc13b9b94.mov">

Плюсы такого подхода:
- минимальное качество можно настроить прям в редакторе, на глаз, т.к. это обычный модификатор
- оптимизирует все меши, где настроили модификатор
- общее количество треугольников получилось меньше, и распределены они вроде как равномернее

По стилю кода / именам - я всё забыл - прошу ревьюить с пристрастием.

Как настраивать:
- добавляем Decimate-модификаторы на меши, для которых хотим генерить LODы и настраиваем минимально допустимый ratio (аддон при экспорте будет увеличивать его с шагом 0.1 и сохранять LOD в SWIDATA)
  <img width="315" alt="image" src="https://user-images.githubusercontent.com/5264687/156083018-adca7c21-bc57-4473-836f-cd1984e39f06.png">
- выбираем этот модификатор в свойствах меша (сам модификатор можно отключить в ренеинге/вьюпорте чтоб не мешался)
  <img width="306" alt="image" src="https://user-images.githubusercontent.com/5264687/156082909-7f092105-a7ae-4086-b08a-94b78ad1bcd8.png">

Если в настройках LOD-модификаторов есть ошибки или просто не сгенерировались доп LODы для объекта с типом Progressive - будут выведены предупреждения:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/5264687/156083259-895ff727-69e5-4cdf-bdcf-99d9c8d08770.png">