### PR TITLE
ltx: log and show syntax errors

### DIFF
--- a/io_scene_xray/prefs/props.py
+++ b/io_scene_xray/prefs/props.py
@@ -1,5 +1,7 @@
 # standart modules
 import os
+import sys
+import traceback
 
 # blender modules
 import bpy
@@ -247,9 +249,10 @@ def _auto_path(prefs, self_name, path_suffix, checker):
             fs = rw.ltx.LtxParser()
             fs.from_file(prefs.fs_ltx_file)
         except:
+            traceback.print_exc()
             utils.draw.show_message(
                 text.get_text(text.error.ltx_invalid_syntax),
-                (prefs.fs_ltx_file, ),
+                (prefs.fs_ltx_file, sys.exc_info()[1]),
                 text.get_text(text.error.error_title),
                 'ERROR'
             )

--- a/io_scene_xray/rw/ltx.py
+++ b/io_scene_xray/rw/ltx.py
@@ -140,4 +140,4 @@ class LtxParser:
                 self.line_index += 1
 
             else:
-                raise BaseException('Invalid *.ltx syntax')
+                raise BaseException(f'Invalid *.ltx syntax: {line}')

--- a/io_scene_xray/rw/ltx.py
+++ b/io_scene_xray/rw/ltx.py
@@ -140,4 +140,4 @@ class LtxParser:
                 self.line_index += 1
 
             else:
-                raise BaseException(f'Invalid *.ltx syntax: {line}')
+                raise BaseException('Invalid *.ltx syntax: ' + line)

--- a/io_scene_xray/utils/draw.py
+++ b/io_scene_xray/utils/draw.py
@@ -59,7 +59,7 @@ def show_message(
             if message_text:
                 self.layout.label(text=message + '.')
         for element in elements:
-            self.layout.label(text=' ' * 4 + element)
+            self.layout.label(text=' ' * 4 + str(element))
         if operators:
             self.layout.operator_context = 'INVOKE_DEFAULT'
             for op_index, operator in enumerate(operators):


### PR DESCRIPTION
Would help to easily debug issues like #675:
<img width="379" alt="Screenshot 2023-11-10 at 20 02 12" src="https://github.com/PavelBlend/blender-xray/assets/5264687/74f70321-326e-4356-bb1b-ca3ac52470a3">