### PR TITLE
Fix metarial creation for v4.0 BSDF node

### DIFF
--- a/io_scene_xray/formats/level/imp/material.py
+++ b/io_scene_xray/formats/level/imp/material.py
@@ -17,7 +17,7 @@ def _create_shader_output_node(bpy_material, offset):
 
 def _create_shader_principled_node(bpy_material, offset):
     node = bpy_material.node_tree.nodes.new('ShaderNodeBsdfPrincipled')
-    node.inputs['Specular'].default_value = 0.0
+    node.inputs['Specular IOR Level'].default_value = 0.0
     offset.x += 400.0
     node.location = offset
     return node

--- a/io_scene_xray/formats/level/imp/material.py
+++ b/io_scene_xray/formats/level/imp/material.py
@@ -17,7 +17,10 @@ def _create_shader_output_node(bpy_material, offset):
 
 def _create_shader_principled_node(bpy_material, offset):
     node = bpy_material.node_tree.nodes.new('ShaderNodeBsdfPrincipled')
-    node.inputs['Specular IOR Level'].default_value = 0.0
+    if (int(bpy.app.version_string[0]) >= 4):
+        node.inputs['Specular IOR Level'].default_value = 0.0
+    else:
+        node.inputs['Specular'].default_value = 0.0
     offset.x += 400.0
     node.location = offset
     return node

--- a/io_scene_xray/ops/level_shaders.py
+++ b/io_scene_xray/ops/level_shaders.py
@@ -419,7 +419,10 @@ def _create_group_nodes(
         princp_node = shader_group.nodes.new('ShaderNodeBsdfPrincipled')
         princp_node.select = False
         princp_node.location.x = 500
-        princp_node.inputs['Specular IOR Level'].default_value = 0.0
+        if (int(bpy.app.version_string[0]) >= 4):
+            princp_node.inputs['Specular IOR Level'].default_value = 0.0
+        else:
+            princp_node.inputs['Specular'].default_value = 0.0
 
         # link shader
         shader_group.links.new(
@@ -679,7 +682,10 @@ def _create_base_nodes(mat, img):
     princp_node.select = False
     princp_node.location.x = 10
     princp_node.location.y = 300
-    princp_node.inputs['Specular IOR Level'].default_value = 0.0
+    if (int(bpy.app.version_string[0]) >= 4):
+        princp_node.inputs['Specular IOR Level'].default_value = 0.0
+    else:
+        princp_node.inputs['Specular'].default_value = 0.0
 
     # create image node
     img_node = mat.node_tree.nodes.new('ShaderNodeTexImage')

--- a/io_scene_xray/ops/level_shaders.py
+++ b/io_scene_xray/ops/level_shaders.py
@@ -419,7 +419,7 @@ def _create_group_nodes(
         princp_node = shader_group.nodes.new('ShaderNodeBsdfPrincipled')
         princp_node.select = False
         princp_node.location.x = 500
-        princp_node.inputs['Specular'].default_value = 0.0
+        princp_node.inputs['Specular IOR Level'].default_value = 0.0
 
         # link shader
         shader_group.links.new(
@@ -679,7 +679,7 @@ def _create_base_nodes(mat, img):
     princp_node.select = False
     princp_node.location.x = 10
     princp_node.location.y = 300
-    princp_node.inputs['Specular'].default_value = 0.0
+    princp_node.inputs['Specular IOR Level'].default_value = 0.0
 
     # create image node
     img_node = mat.node_tree.nodes.new('ShaderNodeTexImage')

--- a/io_scene_xray/ops/shader.py
+++ b/io_scene_xray/ops/shader.py
@@ -276,7 +276,10 @@ class XRAY_OT_change_shader_params(utils.ie.BaseOperator):
                     self.report({'WARNING'}, 'Material "{}" has no principled shader.'.format(mat.name))
                     continue
                 if self.specular_change:
-                    shader_node.inputs["Specular IOR Level"].default_value = self.specular_value
+                    if (int(bpy.app.version_string[0]) >= 4):
+                        shader_node.inputs['Specular IOR Level'].default_value = self.specular_value
+                    else:
+                        shader_node.inputs['Specular'].default_value = self.specular_value
                 if self.roughness_change:
                     shader_node.inputs['Roughness'].default_value = self.roughness_value
                 if not self.alpha_change:

--- a/io_scene_xray/ops/shader.py
+++ b/io_scene_xray/ops/shader.py
@@ -276,7 +276,7 @@ class XRAY_OT_change_shader_params(utils.ie.BaseOperator):
                     self.report({'WARNING'}, 'Material "{}" has no principled shader.'.format(mat.name))
                     continue
                 if self.specular_change:
-                    shader_node.inputs['Specular'].default_value = self.specular_value
+                    shader_node.inputs["Specular IOR Level"].default_value = self.specular_value
                 if self.roughness_change:
                     shader_node.inputs['Roughness'].default_value = self.roughness_value
                 if not self.alpha_change:

--- a/io_scene_xray/utils/material.py
+++ b/io_scene_xray/utils/material.py
@@ -180,7 +180,7 @@ def create_mat_nodes(bpy_material):
     princ_node = node_tree.nodes.new('ShaderNodeBsdfPrincipled')
     princ_node.location.x = 10.0
     princ_node.location.y = 300.0
-    princ_node.inputs['Specular'].default_value = 0.0
+    princ_node.inputs['Specular IOR Level'].default_value = 0.0
     princ_node.select = False
 
     # create output node

--- a/io_scene_xray/utils/material.py
+++ b/io_scene_xray/utils/material.py
@@ -180,7 +180,10 @@ def create_mat_nodes(bpy_material):
     princ_node = node_tree.nodes.new('ShaderNodeBsdfPrincipled')
     princ_node.location.x = 10.0
     princ_node.location.y = 300.0
-    princ_node.inputs['Specular IOR Level'].default_value = 0.0
+    if (int(bpy.app.version_string[0]) >= 4):
+        princ_node.inputs['Specular IOR Level'].default_value = 0.0
+    else:
+        princ_node.inputs['Specular'].default_value = 0.0
     princ_node.select = False
 
     # create output node


### PR DESCRIPTION
Added support for 4.0 version of Blenders BSDF Node:
![image](https://github.com/PavelBlend/blender-xray/assets/85461004/0b5a5bf2-f317-48ed-ac4e-d9f7bca1981f)
For old version was problem with changing "Specular" when importing models, it calls now "Specular IOR Level".