### PR TITLE
Make testsuite better again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+/.tests/
 htmlcov
 coverage.xml
 *.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,3 +21,9 @@ test_script:
 
 after_test:
   - bash <(curl -s https://codecov.io/bash)
+
+artifacts:
+  - path: .tests
+on_failure:
+  - 7z a tests.zip .tests
+  - appveyor PushArtifact tests.zip

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,11 +13,9 @@ To do this, you could download the package archive and extract the `coverage` fo
 To run all tests, invoke the `runner.py` script from the repository-root directory using `blender`:
 
 ```shell
-blender --factory-startup -noaudio -b --python tests/runner.py --save-html-report output_folder --save-test-data
+blender --factory-startup -noaudio -b --python tests/runner.py --save-html-report output_folder
 ```
 The `--save-html-report output_folder` parameter is optional. If all tests are passed, the `./htmlcov/` directory with coverage reports will be created.
-
-The `--save-test-data` parameter is optional. If this parameter is present, then files created during tests in the temporary directory will not be deleted.
 
 To start tests for all `blender` versions, you can use such commands for `windows`:
 


### PR DESCRIPTION
Раньше результаты тестов
- сохранялись хрен-пойми куда, каждый раз в новый временный каталог
- удалялись, если не передать флаг

Теперь:
- сохраняются в каталог проекта
- удаляются перед запуском => всегда есть результаты последнего запуска
- автоматом сохраняется blend-файл упавшего теста - чтоб можно было посмотреть, что он там нагенерировал

А ещё - их можно скачать из CI:
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/608b1c92-5ae8-41ce-8b85-79615599202e">
