### PR TITLE
Tests: run particular test methods and classes that match the pattern or substring

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -13,9 +13,11 @@ To do this, you could download the package archive and extract the `coverage` fo
 To run all tests, invoke the `runner.py` script from the repository-root directory using `blender`:
 
 ```shell
-blender --factory-startup -noaudio -b --python tests/runner.py --save-html-report output_folder
+blender --factory-startup -noaudio -b --python tests/runner.py --save-html-report output_folder -k 'test*shape'
 ```
 The `--save-html-report output_folder` parameter is optional. If all tests are passed, the `./htmlcov/` directory with coverage reports will be created.
+
+The `-k` parameter is optional and can be used to run test methods and classes that match the pattern or substring (just like [-k](https://docs.python.org/3/library/unittest.html#cmdoption-unittest-k) in `unittest`).
 
 To start tests for all `blender` versions, you can use such commands for `windows`:
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -11,8 +11,16 @@ except:
 cov.combine(keep=True)
 cov.start()
 
-suite = unittest.defaultTestLoader.discover('.')
-if not unittest.TextTestRunner().run(suite).wasSuccessful():
+loader = unittest.TestLoader()
+for i, v in enumerate(sys.argv):
+    if v == '-k':
+        pattern = sys.argv[i + 1]
+        if '*' not in pattern:
+            pattern = '*' + pattern + '*'
+        loader.testNamePatterns = (loader.testNamePatterns or []) + [pattern]
+
+suite = loader.discover('.')
+if not unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful():
     exit(1)
 
 cov.stop()


### PR DESCRIPTION
like https://docs.python.org/3/library/unittest.html#cmdoption-unittest-k

и в логах теперь понятно, от какого теста сообщения, а не просто в каждой строчке только точки)
<img width="907" alt="image" src="https://github.com/user-attachments/assets/c112257f-0159-4900-b696-64239e2c755a">
